### PR TITLE
docs(2.0.x): correction field of timeout

### DIFF
--- a/app/2.0.x/proxy.md
+++ b/app/2.0.x/proxy.md
@@ -924,7 +924,7 @@ properties of a Service:
 
 - `connect_timeout`: defines in milliseconds the timeout for
   establishing a connection to your upstream service. Defaults to `60000`.
-- `send_timeout`: defines in milliseconds a timeout between two
+- `write_timeout`: defines in milliseconds a timeout between two
   successive write operations for transmitting a request to your upstream
   service.  Defaults to `60000`.
 - `read_timeout`: defines in milliseconds a timeout between two

--- a/app/2.0.x/proxy.md
+++ b/app/2.0.x/proxy.md
@@ -922,12 +922,12 @@ to forward the request to your upstream service. This is done via Nginx's
 timeouts for the connection between Kong and a given upstream, via the following
 properties of a Service:
 
-- `upstream_connect_timeout`: defines in milliseconds the timeout for
+- `connect_timeout`: defines in milliseconds the timeout for
   establishing a connection to your upstream service. Defaults to `60000`.
-- `upstream_send_timeout`: defines in milliseconds a timeout between two
+- `send_timeout`: defines in milliseconds a timeout between two
   successive write operations for transmitting a request to your upstream
   service.  Defaults to `60000`.
-- `upstream_read_timeout`: defines in milliseconds a timeout between two
+- `read_timeout`: defines in milliseconds a timeout between two
   successive read operations for receiving a request from your upstream
   service.  Defaults to `60000`.
 


### PR DESCRIPTION
Correction field of service timeout,
`connect_timeout`, `send_timeout` and `read_timeout`.

<!--
**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md
-->

